### PR TITLE
Version 0.0.14: Fix vapor frac

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ahuora-compounds"
-version = "0.0.13"
+version = "0.0.14"
 
 authors = [
   { name="Example Author", email="author@example.com" },


### PR DESCRIPTION
Added a test to show the issue.

When setting vapor fraction, it's weird because vapor fraction cuts off below and above 0 and 1. This makes it hard for the solver to converge on a value because  if it's outside the vapor region, vapor fraction doesn't seem to be changing. 

Alma made a fix that made a new constraint, but this didn't work as it did not get the value from the constraint correctly.

This fixes that and tests it


