### PR TITLE
set reference enthalpy for milk water to be the same as helmholtz 

### DIFF
--- a/property_packages/milk/milk_modular.py
+++ b/property_packages/milk/milk_modular.py
@@ -51,7 +51,7 @@ _log = logging.getLogger(__name__)
 milk_configuration = {
     # Specifying components
     "components": {
-        "water": {
+        "h2o": {
             "type": Component,
             "dens_mol_liq_comp": Perrys,
             "enth_mol_liq_comp": Perrys,
@@ -98,7 +98,7 @@ milk_configuration = {
                     ),
                     "F": (-250.8810, pyunits.kJ / pyunits.mol),
                     "G": (223.3967, pyunits.J / pyunits.mol / pyunits.K),
-                    "H": (0, pyunits.kJ / pyunits.mol),
+                    "H": (-241.83 - 45.6, pyunits.kJ / pyunits.mol),
                 },
                 "cp_mol_liq_comp_coeff": {
                     "1": (
@@ -110,11 +110,11 @@ milk_configuration = {
                     "4": (-1.4116e-2, pyunits.J / pyunits.kmol / pyunits.K**4),
                     "5": (9.3701e-6, pyunits.J / pyunits.kmol / pyunits.K**5),
                 },
+                # NIST ignores enth_mol_form_ig_comp_ref, and uses the H parameter instead.
                 "enth_mol_form_liq_comp_ref": (
-                    -285.83e3,
+                    0, # With "include_enthalpy_of_formation": False, Perrys actually ignores this.
                     pyunits.J / pyunits.mol,
                 ),  # [1]
-                "enth_mol_form_vap_comp_ref": (0, pyunits.J / pyunits.mol),  # [1]
                 "entr_mol_form_liq_comp_ref": (
                     69.95, 
                     pyunits.J / pyunits.mol / pyunits.K,
@@ -193,10 +193,11 @@ milk_configuration = {
         "temperature": (273.15, 323.15, 1000, pyunits.K),
         "pressure": (10000, 108900, 1e7, pyunits.Pa),
     },
-    "pressure_ref": (101325, pyunits.Pa),
-    "temperature_ref": (298.15, pyunits.K),
+    "pressure_ref": (611, pyunits.Pa),
+    "temperature_ref": (275.25, pyunits.K),
     # Defining phase equilibria
     "phases_in_equilibrium": [("Vap", "Liq")],
     "phase_equilibrium_state": {("Vap", "Liq"): SmoothVLE},
     "bubble_dew_method": IdealBubbleDew,
+    "include_enthalpy_of_formation": False,
 }

--- a/property_packages/milk/milk_modular.py
+++ b/property_packages/milk/milk_modular.py
@@ -51,7 +51,7 @@ _log = logging.getLogger(__name__)
 milk_configuration = {
     # Specifying components
     "components": {
-        "h2o": {
+        "water": {
             "type": Component,
             "dens_mol_liq_comp": Perrys,
             "enth_mol_liq_comp": Perrys,

--- a/property_packages/milk/milk_modular.py
+++ b/property_packages/milk/milk_modular.py
@@ -97,7 +97,7 @@ milk_configuration = {
                         pyunits.J * pyunits.mol**-1 * pyunits.K**-1 * pyunits.kiloK**2,
                     ),
                     "F": (-250.8810, pyunits.kJ / pyunits.mol),
-                    "G": (223.3967, pyunits.J / pyunits.mol / pyunits.K),
+                    "G": (202.3, pyunits.J / pyunits.mol / pyunits.K),
                     "H": (-241.83 - 45.6, pyunits.kJ / pyunits.mol),
                 },
                 "cp_mol_liq_comp_coeff": {
@@ -116,11 +116,11 @@ milk_configuration = {
                     pyunits.J / pyunits.mol,
                 ),  # [1]
                 "entr_mol_form_liq_comp_ref": (
-                    69.95, 
+                    0, 
                     pyunits.J / pyunits.mol / pyunits.K,
                 ),  # [1]
                 "entr_mol_form_vap_comp_ref": (
-                    188.835,  
+                    0,# AGAIN, NIST doesn't use this  
                     pyunits.J / pyunits.mol / pyunits.K,
                 ),  # [1]
                 "pressure_sat_comp_coeff": {
@@ -165,9 +165,8 @@ milk_configuration = {
                     pyunits.J / pyunits.mol,
                 ),  # [1]
                 # formation is phase transition. Entropy associated with going from solid to liquid.
-                # for now we are just using oleic acid. https://webbook.nist.gov/cgi/cbook.cgi?ID=C112801&Mask=6F
                 "entr_mol_form_liq_comp_ref": (
-                    138.4,
+                    0,
                     pyunits.J / pyunits.mol / pyunits.K,
                 ),
             },
@@ -193,8 +192,8 @@ milk_configuration = {
         "temperature": (273.15, 323.15, 1000, pyunits.K),
         "pressure": (10000, 108900, 1e7, pyunits.Pa),
     },
-    "pressure_ref": (611, pyunits.Pa),
-    "temperature_ref": (275.25, pyunits.K),
+    "pressure_ref": (612.5, pyunits.Pa),
+    "temperature_ref": (273.2, pyunits.K),
     # Defining phase equilibria
     "phases_in_equilibrium": [("Vap", "Liq")],
     "phase_equilibrium_state": {("Vap", "Liq"): SmoothVLE},

--- a/property_packages/milk/tests/test_milk.py
+++ b/property_packages/milk/tests/test_milk.py
@@ -105,9 +105,9 @@ def test_vap_frac_fix():
 
     assert value(m.fs.state_block.flow_mass) == approx(0.0201, abs=1e-4)
 
-    assert value(m.fs.state_block.entr_mol) == approx(124.03149421673038, rel=1e-2)
+    assert value(m.fs.state_block.entr_mol) == approx(78.11263952439862, rel=1e-2)
 
-    assert value(m.fs.state_block.entr_mass) == approx(6153.8372548587195, abs=1e2)
+    assert value(m.fs.state_block.entr_mass) == approx(3875.567848442111, abs=1e2)
 
     assert degrees_of_freedom(m) == 0
 

--- a/property_packages/milk/tests/test_milk.py
+++ b/property_packages/milk/tests/test_milk.py
@@ -98,16 +98,16 @@ def test_vap_frac_fix():
     m.fs.state_block.entr_mol # trigger entropy build
     # Values not verified
 
-    assert value(m.fs.state_block.enth_mol) == approx(-264540.76, abs=1e4)
+    assert value(m.fs.state_block.enth_mol) == approx(27729.048812434226, abs=1e4)
 
-    assert value(m.fs.state_block.enth_mass) == approx(-12745765.14624959, abs=1e5)
+    assert value(m.fs.state_block.enth_mass) == approx(1375780.0363638315, abs=1e5)
 
 
     assert value(m.fs.state_block.flow_mass) == approx(0.0201, abs=1e-4)
 
-    assert value(m.fs.state_block.entr_mol) == approx(142.31538514734717, rel=1e-2)
+    assert value(m.fs.state_block.entr_mol) == approx(124.03149421673038, rel=1e-2)
 
-    assert value(m.fs.state_block.entr_mass) == approx(7060.99466583044, abs=1e2)
+    assert value(m.fs.state_block.entr_mass) == approx(6153.8372548587195, abs=1e2)
 
     assert degrees_of_freedom(m) == 0
 
@@ -115,4 +115,4 @@ def test_vap_frac_fix():
     solver.solve(m)
     assert value(m.fs.state_block.vapor_frac) == approx(0.5, abs=1e-4)
     assert value(m.fs.state_block.flow_vol) == approx(2.6e-5, abs=1e-2)
-    assert value(m.fs.state_block.total_energy_flow) == approx(-256892.76, abs=1e3)
+    assert value(m.fs.state_block.total_energy_flow) == approx(27729.048811843582, abs=1e3)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ahuora-compounds"
-version = "0.0.26"
+version = "0.0.27"
 
 authors = [
   { name="Example Author", email="author@example.com" },


### PR DESCRIPTION
so that we can use enthalpy translator blocks.