### PR TITLE
Temperature bubble helmholtz

### DIFF
--- a/property_packages/helmholtz/tests/test_helmholtz.py
+++ b/property_packages/helmholtz/tests/test_helmholtz.py
@@ -91,4 +91,7 @@ def test_vapor_fraction_ammonia():
     assert value(m.fs.sb[0].flow_mol) == approx(100)
     assert value(m.fs.sb[0].vapor_frac) == approx(0.8)
     assert value(m.fs.sb[0].pressure) == approx(614294.349)
+    # check that temperature_bubble exists
+    assert value(m.fs.sb[0].temperature_bubble) == approx(283.1266) 
+    assert value(m.fs.sb[0].temperature_dew) == approx(283.1266)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ahuora-compounds"
-version = "0.0.29"
+version = "0.0.30"
 
 authors = [
   { name="Example Author", email="author@example.com" },


### PR DESCRIPTION
the generic property package supports temperature_bubble and temperature_dew.

In helmholtz, as it is a pure component, these are the same, and referenced under temperature_sat.

We want to not have to change the properties between the two, so this just adds references to temperature_sat.